### PR TITLE
Fix bathroom scanner view integration

### DIFF
--- a/bathroom.html
+++ b/bathroom.html
@@ -1,56 +1,52 @@
+<!-- bathroom.html (included by sidebar.html) -->
+<style>
+  .container-fluid {
+    padding-top: 20px;
+  }
+  #scanner-container {
+    position: relative;
+  }
+  #qr-reader {
+    width: 100%;
+  }
+  #qr-reader-results {
+    margin-top: 20px;
+  }
+</style>
+
 <div id="mainBathroom" class="main">
-<!DOCTYPE html>
-<html>
-  <head>
-    <base target="_top">
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@simonwep/pickr/dist/themes/classic.min.css"/>
-    <style>
-      .container-fluid {
-        padding-top: 20px;
-      }
-      #scanner-container {
-        position: relative;
-      }
-      #qr-reader {
-        width: 100%;
-      }
-      #qr-reader-results {
-        margin-top: 20px;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="container-fluid">
-      <h4>Bathroom Break Scanner</h4>
-      <div id="scanner-container">
-        <div id="qr-reader" style="width: 500px"></div>
-        <div id="qr-reader-results"></div>
-      </div>
+  <div class="container-fluid">
+    <h4>Bathroom Break Scanner</h4>
+    <div id="scanner-container">
+      <div id="qr-reader" style="width: 500px"></div>
+      <div id="qr-reader-results"></div>
     </div>
-
-    <script src="https://unpkg.com/html5-qrcode"></script>
-    <script>
-      function onScanSuccess(decodedText, decodedResult) {
-        // Handle on success condition with the decoded text or result.
-        console.log(`Scan result: ${decodedText}`, decodedResult);
-        document.getElementById('qr-reader-results').innerText = `Last scan: ${decodedText}`;
-        google.script.run.withSuccessHandler(updateUI).withFailureHandler(showError).processBarcode(decodedText);
-      }
-
-      function updateUI(message) {
-        alert(message);
-      }
-
-      function showError(error) {
-        alert(error.message);
-      }
-
-      var html5QrcodeScanner = new Html5QrcodeScanner(
-        "qr-reader", { fps: 10, qrbox: 250 });
-      html5QrcodeScanner.render(onScanSuccess);
-    </script>
-  </body>
-</html>
+  </div>
 </div>
+
+<script src="https://unpkg.com/html5-qrcode"></script>
+<script>
+  function onScanSuccess(decodedText, decodedResult) {
+    console.log(`Scan result: ${decodedText}`, decodedResult);
+    document.getElementById('qr-reader-results').innerText = `Last scan: ${decodedText}`;
+    google.script.run
+      .withSuccessHandler(updateUI)
+      .withFailureHandler(showError)
+      .processBarcode(decodedText);
+  }
+
+  function updateUI(message) {
+    alert(message);
+    if (typeof renderBathroomAnalytics === 'function') {
+      renderBathroomAnalytics();
+    }
+  }
+
+  function showError(error) {
+    alert(error.message);
+  }
+
+  const html5QrcodeScanner = new Html5QrcodeScanner('qr-reader', { fps: 10, qrbox: 250 });
+  html5QrcodeScanner.render(onScanSuccess);
+</script>
+

--- a/sidebar.html
+++ b/sidebar.html
@@ -416,7 +416,12 @@
     $('#mainLog').classList.toggle('active', view==='log');
     $('#mainAnalytics').classList.toggle('active', view==='analytics');
     $('#mainBathroom').classList.toggle('active', view==='bathroom'); // New line
-    if (view === 'analytics') renderAnalytics(); // use local COUNTS
+    if (view === 'analytics') {
+      renderAnalytics(); // use local COUNTS
+      if (typeof renderBathroomAnalytics === 'function') {
+        renderBathroomAnalytics();
+      }
+    }
     // No specific render function for bathroom yet, but it will be loaded.
   }
 


### PR DESCRIPTION
## Summary
- Restructure `bathroom.html` into a partial and wire the QR scanner to trigger analytics refresh after each scan.
- Refresh bathroom analytics whenever the Analytics view is opened.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68af36650fdc832f9a0ff83dca4b850d