### PR TITLE
Improve bathroom analytics

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -844,17 +844,19 @@ function getBathroomAnalytics() {
     const studentName = row[2];
     const period = row[3];
     const direction = row[4];
+    const duration = parseInt(row[5], 10) || 0;
 
-    if (!analytics.students[studentName]) {
-      analytics.students[studentName] = { out: 0, in: 0 };
-    }
-    if (!analytics.periods[period]) {
-      analytics.periods[period] = { out: 0, in: 0 };
-    }
-
-    if (direction === 'out' || direction === 'in') {
-      analytics.students[studentName][direction] += 1;
-      analytics.periods[period][direction] += 1;
+    if (direction === 'in') {
+      if (!analytics.students[studentName]) {
+        analytics.students[studentName] = { visits: 0, minutes: 0 };
+      }
+      if (!analytics.periods[period]) {
+        analytics.periods[period] = { visits: 0, minutes: 0 };
+      }
+      analytics.students[studentName].visits += 1;
+      analytics.students[studentName].minutes += duration;
+      analytics.periods[period].visits += 1;
+      analytics.periods[period].minutes += duration;
     }
   }
 

--- a/analytics.html
+++ b/analytics.html
@@ -143,8 +143,8 @@
           <thead>
             <tr>
               <th>Period</th>
-              <th style="width:80px">Out</th>
-              <th style="width:80px">In</th>
+              <th style="width:80px">Visits</th>
+              <th style="width:80px">Minutes</th>
             </tr>
           </thead>
           <tbody></tbody>
@@ -162,9 +162,9 @@
       <table class="table" id="bathroomAnalyticsTable">
         <thead>
           <tr>
-            <th>Student</th>
-            <th style="width:80px">Out</th>
-            <th style="width:80px">In</th>
+              <th>Student</th>
+              <th style="width:80px">Visits</th>
+              <th style="width:80px">Minutes</th>
           </tr>
         </thead>
         <tbody></tbody>
@@ -311,11 +311,11 @@
         for (const student in students) {
           const tr = document.createElement('tr');
           const s = students[student] || {};
-          tr.append(
-            el('td', {}, student),
-            el('td', {}, String(s.out || 0)),
-            el('td', {}, String(s.in || 0))
-          );
+            tr.append(
+              el('td', {}, student),
+              el('td', {}, String(s.visits || 0)),
+              el('td', {}, String(s.minutes || 0))
+            );
           studentBody.appendChild(tr);
         }
       }
@@ -330,11 +330,11 @@
         for (const period in periods) {
           const tr = document.createElement('tr');
           const p = periods[period] || {};
-          tr.append(
-            el('td', {}, period),
-            el('td', {}, String(p.out || 0)),
-            el('td', {}, String(p.in || 0))
-          );
+            tr.append(
+              el('td', {}, period),
+              el('td', {}, String(p.visits || 0)),
+              el('td', {}, String(p.minutes || 0))
+            );
           periodBody.appendChild(tr);
         }
       }

--- a/bathroom.html
+++ b/bathroom.html
@@ -56,6 +56,11 @@
   });
   function handleScan(code){
     document.getElementById('scanResult').innerText = `Processing scan: ${code}`;
+    // Optimistically refresh status and analytics so UI updates immediately
+    refreshStatus();
+    if(typeof renderBathroomAnalytics === 'function'){
+      renderBathroomAnalytics();
+    }
     google.script.run
       .withSuccessHandler(updateUI)
       .withFailureHandler(showError)
@@ -63,10 +68,11 @@
   }
   function updateUI(message){
     document.getElementById('scanResult').innerText = message;
+    // Refresh status first so check-in/out lists update promptly
+    refreshStatus();
     if(typeof renderBathroomAnalytics === 'function'){
       renderBathroomAnalytics();
     }
-    refreshStatus();
     barcodeInput.focus();
   }
   function showError(error){


### PR DESCRIPTION
## Summary
- Track bathroom visits by total minutes and visit count instead of in/out events
- Start status and analytics refreshes immediately after scans for snappier updates

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68af440278bc832faa8f3d514c28d398