### PR TITLE
Fix bathroom timestamps and reorganize analytics

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -886,7 +886,9 @@ function getBathroomStatus(period) {
   for (let i = 1; i < data.length; i++) {
     const row = data[i];
     const ts = new Date(row[0]);
-    if (ts.setHours(0, 0, 0, 0) !== today) continue;
+    const day = new Date(ts);
+    day.setHours(0, 0, 0, 0);
+    if (day.getTime() !== today) continue;
     if (p && row[3] !== p) continue;
     const id = row[1];
     const name = row[2];

--- a/analytics.html
+++ b/analytics.html
@@ -112,59 +112,36 @@
   </div>
 
   <!-- Details and Bathroom Visits by Period -->
-  <div class="section" aria-label="Details and bathroom visits by period">
+  <div class="panel table-panel" aria-label="Details and bathroom visits by period">
     <!-- Details (Current Period) -->
-    <div class="panel table-panel" aria-label="Student details table">
-      <div class="table-toolbar">
-        <div class="panel-title" style="margin:0">Details (Current Period)</div>
-        <div class="muted">Tip: click headers to sort</div>
-      </div>
-      <div class="table-wrap">
-        <table class="table" id="analyticsTable">
-          <thead>
-            <tr>
-              <th><button class="th-btn" data-sort="student" aria-label="Sort by student">Student</button></th>
-              <th style="width:120px"><button class="th-btn" data-sort="total" aria-label="Sort by total">Total</button></th>
-              <th><button class="th-btn" data-sort="top" aria-label="Sort by top issue">Top Issue</button></th>
-            </tr>
-          </thead>
-          <tbody></tbody>
-        </table>
-      </div>
+    <div class="table-toolbar">
+      <div class="panel-title" style="margin:0">Details (Current Period)</div>
+      <div class="muted">Tip: click headers to sort</div>
+    </div>
+    <div class="table-wrap">
+      <table class="table" id="analyticsTable">
+        <thead>
+          <tr>
+            <th><button class="th-btn" data-sort="student" aria-label="Sort by student">Student</button></th>
+            <th style="width:120px"><button class="th-btn" data-sort="total" aria-label="Sort by total">Total</button></th>
+            <th><button class="th-btn" data-sort="top" aria-label="Sort by top issue">Top Issue</button></th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
     </div>
 
     <!-- Bathroom Visits by Period -->
-    <div class="panel table-panel" aria-label="Bathroom visits by period table">
-      <div class="table-toolbar">
-        <div class="panel-title" style="margin:0">Bathroom Visits (Today by Period)</div>
-      </div>
-      <div class="table-wrap">
-        <table class="table" id="bathroomPeriodTable">
-          <thead>
-            <tr>
-              <th>Period</th>
-              <th style="width:80px">Visits</th>
-              <th style="width:80px">Minutes</th>
-            </tr>
-          </thead>
-          <tbody></tbody>
-        </table>
-      </div>
-    </div>
-  </div>
-
-  <!-- Bathroom Analytics Table -->
-  <div class="panel table-panel" aria-label="Bathroom analytics table">
     <div class="table-toolbar">
-      <div class="panel-title" style="margin:0">Bathroom Analytics (Today)</div>
+      <div class="panel-title" style="margin:0">Bathroom Visits (Today by Period)</div>
     </div>
     <div class="table-wrap">
-      <table class="table" id="bathroomAnalyticsTable">
+      <table class="table" id="bathroomPeriodTable">
         <thead>
           <tr>
-              <th>Student</th>
-              <th style="width:80px">Visits</th>
-              <th style="width:80px">Minutes</th>
+            <th>Period</th>
+            <th style="width:80px">Visits</th>
+            <th style="width:80px">Minutes</th>
           </tr>
         </thead>
         <tbody></tbody>

--- a/bathroom.html
+++ b/bathroom.html
@@ -39,6 +39,23 @@
       </div>
     </div>
   </div>
+  <div class="panel table-panel" style="grid-column:1 / -1;" aria-label="Bathroom analytics table">
+    <div class="table-toolbar">
+      <div class="panel-title" style="margin:0">Bathroom Analytics (Today)</div>
+    </div>
+    <div class="table-wrap">
+      <table class="table" id="bathroomAnalyticsTable">
+        <thead>
+          <tr>
+            <th>Student</th>
+            <th style="width:80px">Visits</th>
+            <th style="width:80px">Minutes</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </div>
 </div>
 <script>
   const barcodeInput = document.getElementById('barcodeInput');
@@ -108,5 +125,8 @@
     }
   }
   refreshStatus();
+  if(typeof renderBathroomAnalytics === 'function'){
+    renderBathroomAnalytics();
+  }
   document.addEventListener('visibilitychange', ()=>{ if(!document.hidden) barcodeInput.focus(); });
 </script>


### PR DESCRIPTION
## Summary
- Preserve actual checkout timestamps in bathroom status reports
- Merge student details and period bathroom visits into a single analytics panel
- Move per-student bathroom analytics table to the bathroom view

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af46290ee8832f85c72413fef052cd