### PR TITLE
fix: improve Safari UI compatibility

### DIFF
--- a/analytics.html
+++ b/analytics.html
@@ -28,7 +28,7 @@
   .table-wrap{max-height:420px; overflow:auto;}
   .table{width:100%; border-collapse:separate; border-spacing:0 10px; padding:10px 12px;}
   .table thead th{
-    position:sticky; top:0; z-index:1; background:linear-gradient(180deg, #101623, #0c121a);
+    position:-webkit-sticky; position:sticky; top:0; z-index:1; background:linear-gradient(180deg, #101623, #0c121a);
     border-bottom:1px solid #1a2332; color:#b6c6e3; font-size:12px; text-align:left; padding:8px 10px;
   }
   .table td{

--- a/sidebar.html
+++ b/sidebar.html
@@ -22,9 +22,10 @@
 
     /* Header */
     .header{
-      position:sticky; top:0; z-index:6;
+      position:-webkit-sticky; position:sticky; top:0; z-index:6;
       background:linear-gradient(180deg, rgba(16,19,24,.95), rgba(16,19,24,.90));
       border-bottom:1px solid var(--border);
+      -webkit-backdrop-filter:saturate(140%) blur(6px);
       backdrop-filter:saturate(140%) blur(6px);
     }
     .bar{
@@ -183,6 +184,7 @@
     .setup{
       position:fixed; inset:0; display:none; align-items:center; justify-content:center; padding:24px; z-index:8;
       background:linear-gradient(180deg, rgba(10,12,16,.85), rgba(12,16,22,.94));
+      -webkit-backdrop-filter: blur(6px) saturate(140%);
       backdrop-filter: blur(6px) saturate(140%);
     }
     .setup.active{display:flex}


### PR DESCRIPTION
## Summary
- Add WebKit backdrop-filter for blurred header and setup overlay in Safari
- Ensure sticky positioning works in Safari by including -webkit-sticky

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af54f8a614832f90e7287b08a2dcd8