### PR TITLE
Handle trashed sheet and fix Safari layout

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -137,6 +137,7 @@ function _getSpreadsheetOrNull_() {
         return SpreadsheetApp.openById(remembered);
       }
     } catch (e) {}
+    _clearStoredSsId();
   }
   // Container-bound fallback: remember it
   try {

--- a/Code.gs
+++ b/Code.gs
@@ -125,7 +125,7 @@ function _isIdTrashed_(id) {
     const f = DriveApp.getFileById(id);
     return f.isTrashed();
   } catch (e) {
-    return false;
+    return true; // treat unknown or inaccessible files as trashed
   }
 }
 
@@ -145,7 +145,9 @@ function _clearCachesFor_(ssId) {
         keys.push(APP.CACHE_PREFIX_BATH_STATUS + ssId + ':' + p + ':v' + v);
       }
     }
-    cache.removeAll(keys);
+    while (keys.length) {
+      cache.removeAll(keys.splice(0, 100));
+    }
   } catch (e) {}
   try {
     _getScriptProps().deleteProperty(APP.PROP_PREFIX_VER + ssId);

--- a/Code.gs
+++ b/Code.gs
@@ -134,20 +134,30 @@ function _clearCachesFor_(ssId) {
   try {
     const cache = CacheService.getUserCache();
     const ver = _getVersion_(ssId);
-    const keys = [
-      APP.CACHE_PREFIX_DATA + ssId + ':v' + ver,
-      APP.CACHE_PREFIX_BATH_ANALYTICS + ssId + ':v' + ver,
-      APP.CACHE_PREFIX_COUNTS + ssId + '::v' + ver,
-      APP.CACHE_PREFIX_BATH_STATUS + ssId + '::v' + ver,
-    ];
-    for (let p = 0; p <= 10; p++) {
-      keys.push(APP.CACHE_PREFIX_COUNTS + ssId + ':' + p + ':v' + ver);
-      keys.push(APP.CACHE_PREFIX_BATH_STATUS + ssId + ':' + p + ':v' + ver);
+    const keys = [];
+    for (let v = 0; v <= ver; v++) {
+      keys.push(APP.CACHE_PREFIX_DATA + ssId + ':v' + v);
+      keys.push(APP.CACHE_PREFIX_BATH_ANALYTICS + ssId + ':v' + v);
+      keys.push(APP.CACHE_PREFIX_COUNTS + ssId + '::v' + v);
+      keys.push(APP.CACHE_PREFIX_BATH_STATUS + ssId + '::v' + v);
+      for (let p = 0; p <= 10; p++) {
+        keys.push(APP.CACHE_PREFIX_COUNTS + ssId + ':' + p + ':v' + v);
+        keys.push(APP.CACHE_PREFIX_BATH_STATUS + ssId + ':' + p + ':v' + v);
+      }
     }
     cache.removeAll(keys);
   } catch (e) {}
   try {
     _getScriptProps().deleteProperty(APP.PROP_PREFIX_VER + ssId);
+  } catch (e) {}
+}
+
+function _clearAllCaches_() {
+  try {
+    const props = _getScriptProps().getProperties();
+    Object.keys(props)
+      .filter((k) => k.startsWith(APP.PROP_PREFIX_VER))
+      .forEach((k) => _clearCachesFor_(k.substring(APP.PROP_PREFIX_VER.length)));
   } catch (e) {}
 }
 
@@ -297,6 +307,7 @@ function clearAllLogs() {
  * ========================= */
 
 function onOpen() {
+  _clearAllCaches_();
   try {
     const ss = SpreadsheetApp.getActiveSpreadsheet();
     ensureBathroomTrackerSetup_(ss);

--- a/sidebar.html
+++ b/sidebar.html
@@ -103,7 +103,7 @@
     }
     .chip-xs.active{ background:var(--accent); border-color:transparent; color:#fff; box-shadow:0 4px 18px rgba(79,140,255,.35); }
 
-    .list{max-height:calc(100vh - 260px); overflow:auto; padding:10px; transition:all .15s ease;}
+    .list{max-height:calc(100vh - 260px); max-height:calc(100dvh - 260px); overflow:auto; padding:10px; transition:all .15s ease;}
     .filters{display:flex; gap:8px; overflow:auto; padding:10px 12px 0; border-bottom:1px dashed var(--border);}
     .filter-chip{background:#0f1521; border:1px solid var(--chip-border); color:var(--text); padding:6px 10px; border-radius:999px; cursor:pointer; white-space:nowrap; font-size:12px;}
     .filter-chip.active{background:var(--accent); color:#fff; border-color:transparent}
@@ -143,7 +143,7 @@
     }
 
     /* ==== GRID MODE ==== */
-    .list.grid { display:grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap:12px; max-height:calc(100vh - 260px); overflow:auto; }
+    .list.grid { display:grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap:12px; max-height:calc(100vh - 260px); max-height:calc(100dvh - 260px); overflow:auto; }
     .list.grid .student-item{
       grid-template-columns: 1fr; padding:12px; border:1px solid var(--border); background:#0f1521;
     }


### PR DESCRIPTION
## Summary
- Clear stored sheet ID when it's trashed so the app treats it as unattached
- Adjust CSS to use dynamic viewport height for better layout in Safari

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68af5ef35ff4832f9d24e5d20365f809