### PR TITLE
Handle missing spreadsheet for bathroom helpers

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -203,9 +203,9 @@ async function _getSpreadsheetOrNull_() {
 }
 
 async function _getSpreadsheet_() {
-  const ss = await _getSpreadsheetOrNull_();
+  let ss = await _getSpreadsheetOrNull_();
   if (!ss) {
-    throw new Error('No data spreadsheet is attached yet. Use “Build Sheets” first.');
+    ss = await _createSpreadsheet_(APP.DEFAULT_SS_NAME);
   }
   return ss;
 }
@@ -244,8 +244,10 @@ async function getAppState() {
     hasData: { roster:false, issues:false, log:false }
   };
 
-  const ss = await _getSpreadsheetOrNull_();
-  if (!ss) return state;
+  let ss = await _getSpreadsheetOrNull_();
+  if (!ss) {
+    ss = await _createSpreadsheet_(APP.DEFAULT_SS_NAME);
+  }
 
   state.attached = true;
   state.ssId = ss.getId();

--- a/Code.gs
+++ b/Code.gs
@@ -38,39 +38,45 @@ const CONFIG = {
  * Robust property storage (User + Script)
  * ========================= */
 
-function _getUserProps()    { return PropertiesService.getUserProperties(); }
-function _getScriptProps()  { return PropertiesService.getScriptProperties(); }
+async function _getUserProps()    { return PropertiesService.getUserProperties(); }
+async function _getScriptProps()  { return PropertiesService.getScriptProperties(); }
 
-function _getStoredSsId() {
-  const u = _getUserProps().getProperty(APP.PROP_KEY_SS_ID);
-  if (u) return u;
-  const s = _getScriptProps().getProperty(APP.PROP_KEY_SS_ID);
-  return s || null;
+async function _getStoredSsId() {
+  const u = await _getUserProps();
+  const uId = u.getProperty(APP.PROP_KEY_SS_ID);
+  if (uId) return uId;
+  const s = await _getScriptProps();
+  const sId = s.getProperty(APP.PROP_KEY_SS_ID);
+  return sId || null;
 }
-function _setStoredSsId(ssId) {
+async function _setStoredSsId(ssId) {
   if (!ssId) return;
-  _getUserProps().setProperty(APP.PROP_KEY_SS_ID, ssId);
-  _getScriptProps().setProperty(APP.PROP_KEY_SS_ID, ssId);
+  const up = await _getUserProps();
+  up.setProperty(APP.PROP_KEY_SS_ID, ssId);
+  const sp = await _getScriptProps();
+  sp.setProperty(APP.PROP_KEY_SS_ID, ssId);
 }
-function _clearStoredSsId() {
-  _getUserProps().deleteProperty(APP.PROP_KEY_SS_ID);
-  _getScriptProps().deleteProperty(APP.PROP_KEY_SS_ID);
+async function _clearStoredSsId() {
+  const up = await _getUserProps();
+  up.deleteProperty(APP.PROP_KEY_SS_ID);
+  const sp = await _getScriptProps();
+  sp.deleteProperty(APP.PROP_KEY_SS_ID);
 }
 
 /* =========================
  * Versioning for cache invalidation
  * ========================= */
 
-function _getVersion_(ssId) {
+async function _getVersion_(ssId) {
   if (!ssId) return 0;
-  const sp = _getScriptProps();
+  const sp = await _getScriptProps();
   const raw = sp.getProperty(APP.PROP_PREFIX_VER + ssId);
   return raw ? parseInt(raw, 10) || 0 : 0;
 }
-function _bumpVersion_(ssId) {
+async function _bumpVersion_(ssId) {
   if (!ssId) return;
-  const sp = _getScriptProps();
-  const current = _getVersion_(ssId);
+  const sp = await _getScriptProps();
+  const current = await _getVersion_(ssId);
   sp.setProperty(APP.PROP_PREFIX_VER + ssId, String(current + 1));
 }
 
@@ -78,7 +84,7 @@ function _bumpVersion_(ssId) {
  * Cache helpers
  * ========================= */
 
-function _cacheGet_(key) {
+async function _cacheGet_(key) {
   try {
     const cache = CacheService.getUserCache();
     const val = cache.get(key);
@@ -87,7 +93,7 @@ function _cacheGet_(key) {
     return null;
   }
 }
-function _cachePut_(key, obj, ttlSec) {
+async function _cachePut_(key, obj, ttlSec) {
   try {
     const cache = CacheService.getUserCache();
     cache.put(key, JSON.stringify(obj), ttlSec);
@@ -98,7 +104,7 @@ function _cachePut_(key, obj, ttlSec) {
  * Safe lock acquisition for web app + container-bound
  * ========================= */
 
-function _acquireLock_(ms) {
+async function _acquireLock_(ms) {
   const timeout = Math.max(1, ms || 30000);
 
   // Try document lock first (works in container-bound scripts).
@@ -120,20 +126,20 @@ function _acquireLock_(ms) {
  * Spreadsheet attach / resolve
  * ========================= */
 
-function _isIdTrashed_(id) {
+async function _isIdTrashed_(id) {
   try {
     const f = DriveApp.getFileById(id);
     return f.isTrashed();
   } catch (e) {
-    return true; // treat unknown or inaccessible files as trashed
+    return null; // unknown or inaccessible
   }
 }
 
-function _clearCachesFor_(ssId) {
+async function _clearCachesFor_(ssId) {
   if (!ssId) return;
   try {
     const cache = CacheService.getUserCache();
-    const ver = _getVersion_(ssId);
+    const ver = await _getVersion_(ssId);
     const keys = [];
     for (let v = 0; v <= ver; v++) {
       keys.push(APP.CACHE_PREFIX_DATA + ssId + ':v' + v);
@@ -150,65 +156,86 @@ function _clearCachesFor_(ssId) {
     }
   } catch (e) {}
   try {
-    _getScriptProps().deleteProperty(APP.PROP_PREFIX_VER + ssId);
+    const sp = await _getScriptProps();
+    sp.deleteProperty(APP.PROP_PREFIX_VER + ssId);
   } catch (e) {}
 }
 
-function _clearAllCaches_() {
+async function _clearAllCaches_() {
   try {
-    const props = _getScriptProps().getProperties();
-    Object.keys(props)
-      .filter((k) => k.startsWith(APP.PROP_PREFIX_VER))
-      .forEach((k) => _clearCachesFor_(k.substring(APP.PROP_PREFIX_VER.length)));
+    const sp = await _getScriptProps();
+    const props = sp.getProperties();
+    for (const k of Object.keys(props)) {
+      if (k.startsWith(APP.PROP_PREFIX_VER)) {
+        await _clearCachesFor_(k.substring(APP.PROP_PREFIX_VER.length));
+      }
+    }
   } catch (e) {}
 }
 
-function _getSpreadsheetOrNull_() {
-  const remembered = _getStoredSsId();
+async function _getSpreadsheetOrNull_() {
+  const remembered = await _getStoredSsId();
   if (remembered) {
-    try {
-      if (!_isIdTrashed_(remembered)) {
+    const trashed = await _isIdTrashed_(remembered);
+    if (trashed === false) {
+      try {
         return SpreadsheetApp.openById(remembered);
-      }
-    } catch (e) {}
-    _clearCachesFor_(remembered);
-    _clearStoredSsId();
+      } catch (e) {}
+    } else if (trashed === true) {
+      await _clearCachesFor_(remembered);
+      await _clearStoredSsId();
+    }
   }
   // Container-bound fallback: remember it
   try {
     const active = SpreadsheetApp.getActiveSpreadsheet();
     if (active) {
-      if (!_isIdTrashed_(active.getId())) {
-        _setStoredSsId(active.getId());
+      const activeTrashed = await _isIdTrashed_(active.getId());
+      if (activeTrashed === false) {
+        await _setStoredSsId(active.getId());
         return active;
+      } else if (activeTrashed === true) {
+        await _clearCachesFor_(active.getId());
       }
-      _clearCachesFor_(active.getId());
     }
   } catch (e) {}
   return null;
 }
 
-function _getSpreadsheet_() {
-  const ss = _getSpreadsheetOrNull_();
+async function _getSpreadsheet_() {
+  const ss = await _getSpreadsheetOrNull_();
   if (!ss) {
     throw new Error('No data spreadsheet is attached yet. Use “Build Sheets” first.');
   }
   return ss;
 }
 
-function _createSpreadsheet_(name) {
+async function _createSpreadsheet_(name) {
   const ss = SpreadsheetApp.create(name || APP.DEFAULT_SS_NAME);
-  _setStoredSsId(ss.getId());
+  await _setStoredSsId(ss.getId());
   // any new build invalidates caches
-  _bumpVersion_(ss.getId());
+  await _bumpVersion_(ss.getId());
   return ss;
+}
+
+async function findSpreadsheet(name) {
+  const files = DriveApp.getFilesByName(name || APP.DEFAULT_SS_NAME);
+  while (files.hasNext()) {
+    const f = files.next();
+    if (!f.isTrashed()) {
+      const ssId = f.getId();
+      await _setStoredSsId(ssId);
+      return { ok: true, ssId, ssUrl: f.getUrl() };
+    }
+  }
+  return { ok: false, message: 'No spreadsheet found.' };
 }
 
 /* =========================
  * App state & builder
  * ========================= */
 
-function getAppState() {
+async function getAppState() {
   const state = {
     attached: false,
     ssId: null,
@@ -217,7 +244,7 @@ function getAppState() {
     hasData: { roster:false, issues:false, log:false }
   };
 
-  const ss = _getSpreadsheetOrNull_();
+  const ss = await _getSpreadsheetOrNull_();
   if (!ss) return state;
 
   state.attached = true;
@@ -225,7 +252,7 @@ function getAppState() {
   state.ssUrl = ss.getUrl();
 
   // ensure new bathroom-tracking fields/sheets exist
-  ensureBathroomTrackerSetup_(ss);
+  await ensureBathroomTrackerSetup_(ss);
 
   const roster = ss.getSheetByName(CONFIG.ROSTER_SHEET);
   const issues = ss.getSheetByName(CONFIG.ISSUES_SHEET);
@@ -244,41 +271,41 @@ function getAppState() {
   return state;
 }
 
-function buildSheets(opts) {
+async function buildSheets(opts) {
   const seed = !!(opts && opts.seed !== false); // default true
   const name = (opts && opts.name) || APP.DEFAULT_SS_NAME;
 
-  let ss = _getSpreadsheetOrNull_();
+  let ss = await _getSpreadsheetOrNull_();
   if (!ss) {
-    ss = _createSpreadsheet_(name);
+    ss = await _createSpreadsheet_(name);
   }
 
-  ensureRoster_(ss, seed);
-  ensureIssues_(ss, seed);
-  ensureLog_(ss);
-  ensureIssueCountsPivot_(ss);
-  ensureBathroomTrackerSetup_(ss);
+  await ensureRoster_(ss, seed);
+  await ensureIssues_(ss, seed);
+  await ensureLog_(ss);
+  await ensureIssueCountsPivot_(ss);
+  await ensureBathroomTrackerSetup_(ss);
 
   // bump version to invalidate caches (new build)
-  _bumpVersion_(ss.getId());
+  await _bumpVersion_(ss.getId());
 
   return { ok:true, message:'Sheets are ready.', ssId:ss.getId(), ssUrl:ss.getUrl() };
 }
 
-function clearAllLogs() {
+async function clearAllLogs() {
   try {
-    let ss = _getSpreadsheetOrNull_();
+    let ss = await _getSpreadsheetOrNull_();
     if (!ss) {
-      ss = _createSpreadsheet_(APP.DEFAULT_SS_NAME);
+      ss = await _createSpreadsheet_(APP.DEFAULT_SS_NAME);
     }
 
     // Ensure sheets exist (created if missing)
-    const log = getSheetByName(ss, CONFIG.LOG_SHEET,
+    const log = await getSheetByName(ss, CONFIG.LOG_SHEET,
       ['Timestamp','Student','Period','Issue','Notes']);
-    const bath = getSheetByName(ss, CONFIG.BATHROOM_LOG_SHEET,
+    const bath = await getSheetByName(ss, CONFIG.BATHROOM_LOG_SHEET,
       ['Timestamp', 'Student ID', 'Student Name', 'Period', 'Direction', 'Duration (minutes)']);
 
-    const lock = _acquireLock_(30000);
+    const lock = await _acquireLock_(30000);
     try {
       const lastRow = log.getLastRow();
       if (lastRow > 1) {
@@ -293,8 +320,8 @@ function clearAllLogs() {
       const counts = ss.getSheetByName(CONFIG.COUNTS_SHEET);
       if (counts) counts.clear();
       SpreadsheetApp.flush();
-      ensureIssueCountsPivot_(ss); // rebuild analytics sheet
-      _bumpVersion_(ss.getId()); // invalidate caches
+      await ensureIssueCountsPivot_(ss); // rebuild analytics sheet
+      await _bumpVersion_(ss.getId()); // invalidate caches
       return { ok:true, message:'All logs cleared.' };
     } finally {
       try { lock.releaseLock(); } catch (_) {}
@@ -308,11 +335,11 @@ function clearAllLogs() {
  * UI menu (container-bound)
  * ========================= */
 
-function onOpen() {
-  _clearAllCaches_();
+async function onOpen() {
+  await _clearAllCaches_();
   try {
     const ss = SpreadsheetApp.getActiveSpreadsheet();
-    ensureBathroomTrackerSetup_(ss);
+    await ensureBathroomTrackerSetup_(ss);
     SpreadsheetApp.getUi()
       .createMenu('Issue Logger')
       .addItem('Initialize Tracker (build tabs)', 'initializeTracker')
@@ -326,41 +353,41 @@ function onOpen() {
   }
 }
 
-function initializeTracker() {
+async function initializeTracker() {
   try {
-    const ss = _getSpreadsheet_();
-    ensureRoster_(ss, true);
-    ensureIssues_(ss, true);
-    ensureLog_(ss);
-    ensureIssueCountsPivot_(ss);
-    ensureBathroomTrackerSetup_(ss);
-    _bumpVersion_(ss.getId()); // invalidate caches
+    const ss = await _getSpreadsheet_();
+    await ensureRoster_(ss, true);
+    await ensureIssues_(ss, true);
+    await ensureLog_(ss);
+    await ensureIssueCountsPivot_(ss);
+    await ensureBathroomTrackerSetup_(ss);
+    await _bumpVersion_(ss.getId()); // invalidate caches
     SpreadsheetApp.getUi().alert('Issue Logger is ready.\nUse the menu to open Sidebar / Popup / Full Screen.');
   } catch (e) {
     try { SpreadsheetApp.getUi().alert(e.message); } catch (_) {}
   }
 }
 
-function openLoggerSidebar() {
+async function openLoggerSidebar() {
   const html = HtmlService.createTemplateFromFile('sidebar').evaluate()
     .setTitle('Issue Logger')
     .setSandboxMode(HtmlService.SandboxMode.IFRAME);
   try { SpreadsheetApp.getUi().showSidebar(html); } catch (e) {}
 }
-function openLoggerPopup() {
+async function openLoggerPopup() {
   const html = HtmlService.createTemplateFromFile('sidebar').evaluate()
     .setSandboxMode(HtmlService.SandboxMode.IFRAME)
     .setWidth(CONFIG.POPUP_WIDTH)
     .setHeight(CONFIG.POPUP_HEIGHT);
   try { SpreadsheetApp.getUi().showModalDialog(html, 'Issue Logger'); } catch (e) {}
 }
-function doGet() {
+async function doGet() {
   return HtmlService.createTemplateFromFile('sidebar')
     .evaluate()
     .setTitle('Issue Logger')
     .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
 }
-function openFullScreen() {
+async function openFullScreen() {
   const url = ScriptApp.getService().getUrl();
   if (!url) {
     try {
@@ -382,8 +409,8 @@ function openFullScreen() {
  * Idempotent sheet creators
  * ========================= */
 
-function ensureRoster_(ss, seed) {
-  ss = ss || _getSpreadsheet_();
+async function ensureRoster_(ss, seed) {
+  ss = ss || await _getSpreadsheet_();
   let sh = ss.getSheetByName(CONFIG.ROSTER_SHEET);
   if (!sh) sh = ss.insertSheet(CONFIG.ROSTER_SHEET);
 
@@ -404,8 +431,8 @@ function ensureRoster_(ss, seed) {
   return sh;
 }
 
-function ensureIssues_(ss, seed) {
-  ss = ss || _getSpreadsheet_();
+async function ensureIssues_(ss, seed) {
+  ss = ss || await _getSpreadsheet_();
   let sh = ss.getSheetByName(CONFIG.ISSUES_SHEET);
   if (!sh) sh = ss.insertSheet(CONFIG.ISSUES_SHEET);
 
@@ -426,8 +453,8 @@ function ensureIssues_(ss, seed) {
   return sh;
 }
 
-function ensureLog_(ss) {
-  ss = ss || _getSpreadsheet_();
+async function ensureLog_(ss) {
+  ss = ss || await _getSpreadsheet_();
   let sh = ss.getSheetByName(CONFIG.LOG_SHEET);
   if (!sh) {
     sh = ss.insertSheet(CONFIG.LOG_SHEET);
@@ -448,8 +475,8 @@ function ensureLog_(ss) {
   return sh;
 }
 
-function ensureIssueCountsPivot_(ss) {
-  ss = ss || _getSpreadsheet_();
+async function ensureIssueCountsPivot_(ss) {
+  ss = ss || await _getSpreadsheet_();
   let sh = ss.getSheetByName(CONFIG.COUNTS_SHEET);
   if (!sh) sh = ss.insertSheet(CONFIG.COUNTS_SHEET);
   sh.clear();
@@ -467,19 +494,19 @@ function ensureIssueCountsPivot_(ss) {
  * Data fetchers (CACHED)
  * ========================= */
 
-function getData() {
-  const ss = _getSpreadsheetOrNull_();
+async function getData() {
+  const ss = await _getSpreadsheetOrNull_();
   if (!ss) return { periods: [], perMap: {}, issues: [] };
 
   const ssId = ss.getId();
-  const ver = _getVersion_(ssId);
+  const ver = await _getVersion_(ssId);
   const cacheKey = APP.CACHE_PREFIX_DATA + ssId + ':v' + ver;
 
-  const cached = _cacheGet_(cacheKey);
+  const cached = await _cacheGet_(cacheKey);
   if (cached) return cached;
 
-  const rSh = ensureRoster_(ss, false);
-  const iSh = ensureIssues_(ss, false);
+  const rSh = await ensureRoster_(ss, false);
+  const iSh = await ensureIssues_(ss, false);
 
   const rLast = rSh.getLastRow();
   const iLast = iSh.getLastRow();
@@ -510,7 +537,7 @@ function getData() {
   }
 
   const result = { periods, perMap, issues };
-  _cachePut_(cacheKey, result, CONFIG.CACHE_TTL_DATA);
+  await _cachePut_(cacheKey, result, CONFIG.CACHE_TTL_DATA);
   return result;
 }
 
@@ -518,18 +545,18 @@ function getData() {
  * Counts for a selected Period (CACHED per period).
  * Reads columns B: Student, C: Period, D: Issue only once, tally in memory.
  */
-function getCountsSnapshot(period) {
-  const ss = _getSpreadsheetOrNull_();
+async function getCountsSnapshot(period) {
+  const ss = await _getSpreadsheetOrNull_();
   if (!ss) {
     return { issues: [], rows: [], totalsByIssue: [], totalsByStudent: [], totalLogs: 0, zeroStudents: 0, issueVariety: 0 };
   }
 
   const p = String(period || '');
   const ssId = ss.getId();
-  const ver = _getVersion_(ssId);
+  const ver = await _getVersion_(ssId);
   const cacheKey = APP.CACHE_PREFIX_COUNTS + ssId + ':' + p + ':v' + ver;
 
-  const cached = _cacheGet_(cacheKey);
+  const cached = await _cacheGet_(cacheKey);
   if (cached) return cached;
 
   const rosterSh = ss.getSheetByName(CONFIG.ROSTER_SHEET);
@@ -562,7 +589,7 @@ function getCountsSnapshot(period) {
       totalsByStudent: namesInPeriod.map(n=>({student:n, sum:0})),
       totalLogs: 0, zeroStudents: namesInPeriod.length, issueVariety: 0
     };
-    _cachePut_(cacheKey, emptyResult, CONFIG.CACHE_TTL_COUNTS);
+    await _cachePut_(cacheKey, emptyResult, CONFIG.CACHE_TTL_COUNTS);
     return emptyResult;
   }
 
@@ -606,7 +633,7 @@ function getCountsSnapshot(period) {
   const issueVariety = totalsByIssue.filter(t => t.sum > 0).length;
 
   const result = { issues, rows, totalsByIssue, totalsByStudent, totalLogs, zeroStudents, issueVariety };
-  _cachePut_(cacheKey, result, CONFIG.CACHE_TTL_COUNTS);
+  await _cachePut_(cacheKey, result, CONFIG.CACHE_TTL_COUNTS);
   return result;
 }
 
@@ -614,16 +641,16 @@ function getCountsSnapshot(period) {
  * Logging & Undo (invalidate cache via versioning)
  * ========================= */
 
-function logEntries(payload) {
+async function logEntries(payload) {
   try {
     const entries = (payload && payload.entries) ? payload.entries : [];
     if (!entries.length) return { ok:false, message:'No entries.' };
 
-    const ss = _getSpreadsheet_();
-    const log = ss.getSheetByName(CONFIG.LOG_SHEET) || ensureLog_(ss);
+    const ss = await _getSpreadsheet_();
+    const log = ss.getSheetByName(CONFIG.LOG_SHEET) || await ensureLog_(ss);
 
     // Build Name -> Period map once per call
-    const rosterSh = ss.getSheetByName(CONFIG.ROSTER_SHEET) || ensureRoster_(ss, false);
+    const rosterSh = ss.getSheetByName(CONFIG.ROSTER_SHEET) || await ensureRoster_(ss, false);
     const rLast = rosterSh.getLastRow();
     const rVals = rLast >= 2 ? rosterSh.getRange(2,1,rLast-1,2).getValues() : [];
     const nameToPeriod = new Map();
@@ -633,7 +660,7 @@ function logEntries(payload) {
       if (name) nameToPeriod.set(name, per);
     }
 
-    const lock = _acquireLock_(30000);
+    const lock = await _acquireLock_(30000);
     try {
       const now = new Date();
       const rows = entries.map(e => {
@@ -651,7 +678,7 @@ function logEntries(payload) {
       log.getRange(startRow, 1, rows.length, 5).setValues(rows);
       SpreadsheetApp.flush();
       // bump version -> invalidates caches (counts and data)
-      _bumpVersion_(ss.getId());
+      await _bumpVersion_(ss.getId());
     } finally {
       try { lock.releaseLock(); } catch (_) {}
     }
@@ -661,17 +688,17 @@ function logEntries(payload) {
   }
 }
 
-function deleteLastEntry(payload) {
+async function deleteLastEntry(payload) {
   try {
     const student = String(payload && payload.student || '').trim();
     const issue   = String(payload && payload.issue || '').trim();
     const period  = String(payload && payload.period || '').trim();
     if (!student || !issue) return { ok:false, message:'Missing student or issue.' };
 
-    const ss = _getSpreadsheet_();
-    const log = ss.getSheetByName(CONFIG.LOG_SHEET) || ensureLog_(ss);
+    const ss = await _getSpreadsheet_();
+    const log = ss.getSheetByName(CONFIG.LOG_SHEET) || await ensureLog_(ss);
 
-    const lock = _acquireLock_(30000);
+    const lock = await _acquireLock_(30000);
     try {
       const lastRow = log.getLastRow();
       if (lastRow < 2) return { ok:false, message:'No logs to undo.' };
@@ -688,7 +715,7 @@ function deleteLastEntry(payload) {
           const sheetRow = 2 + i;
           log.deleteRow(sheetRow);
           SpreadsheetApp.flush();
-          _bumpVersion_(ss.getId()); // invalidate caches
+          await _bumpVersion_(ss.getId()); // invalidate caches
           return { ok:true, message:'Deleted last entry.', row: sheetRow };
         }
       }
@@ -705,12 +732,12 @@ function deleteLastEntry(payload) {
  * Diagnostics
  * ========================= */
 
-function pingWrite() {
+async function pingWrite() {
   try {
-    const ss = _getSpreadsheet_();
-    const log = ss.getSheetByName(CONFIG.LOG_SHEET) || ensureLog_(ss);
+    const ss = await _getSpreadsheet_();
+    const log = ss.getSheetByName(CONFIG.LOG_SHEET) || await ensureLog_(ss);
 
-    const lock = _acquireLock_(5000);
+    const lock = await _acquireLock_(5000);
     try {
       const cell = log.getRange('A1');
       const prev = cell.getNote();
@@ -729,7 +756,7 @@ function pingWrite() {
  * Bathroom Tracker
  * ========================= */
 
-function getSheetByName(ss, name, headers) {
+async function getSheetByName(ss, name, headers) {
   let sheet = ss.getSheetByName(name);
   if (!sheet) {
     sheet = ss.insertSheet(name);
@@ -741,18 +768,18 @@ function getSheetByName(ss, name, headers) {
   return sheet;
 }
 
-function addStudentIdColumnToRoster(ss) {
-  ss = ss || _getSpreadsheet_();
-  const rosterSheet = ensureRoster_(ss);
+async function addStudentIdColumnToRoster(ss) {
+  ss = ss || await _getSpreadsheet_();
+  const rosterSheet = await ensureRoster_(ss);
   const headers = rosterSheet.getRange(1, 1, 1, rosterSheet.getLastColumn()).getValues()[0];
   if (headers.indexOf('Student ID') === -1) {
     rosterSheet.getRange(1, headers.length + 1).setValue('Student ID');
   }
 }
 
-function getBathroomBreakLimit(ss) {
-  ss = ss || _getSpreadsheet_();
-  const settingsSheet = getSheetByName(ss, CONFIG.SETTINGS_SHEET, ['Key', 'Value']);
+async function getBathroomBreakLimit(ss) {
+  ss = ss || await _getSpreadsheet_();
+  const settingsSheet = await getSheetByName(ss, CONFIG.SETTINGS_SHEET, ['Key', 'Value']);
   const data = settingsSheet.getDataRange().getValues();
   for (let i = 1; i < data.length; i++) {
     if (data[i][0] === 'Bathroom Break Limit') {
@@ -763,25 +790,25 @@ function getBathroomBreakLimit(ss) {
   return 3;
 }
 
-function ensureBathroomTrackerSetup_(ss) {
-  ss = ss || _getSpreadsheet_();
-  addStudentIdColumnToRoster(ss);
-  const logSheet = getSheetByName(ss, CONFIG.BATHROOM_LOG_SHEET, ['Timestamp', 'Student ID', 'Student Name', 'Period', 'Direction', 'Duration (minutes)']);
+async function ensureBathroomTrackerSetup_(ss) {
+  ss = ss || await _getSpreadsheet_();
+  await addStudentIdColumnToRoster(ss);
+  const logSheet = await getSheetByName(ss, CONFIG.BATHROOM_LOG_SHEET, ['Timestamp', 'Student ID', 'Student Name', 'Period', 'Direction', 'Duration (minutes)']);
   const headers = logSheet.getRange(1, 1, 1, logSheet.getLastColumn()).getValues()[0];
   if (headers.indexOf('Period') === -1) {
     logSheet.insertColumnAfter(3);
     logSheet.getRange(1, 4).setValue('Period');
   }
-  getSheetByName(ss, CONFIG.SETTINGS_SHEET, ['Key', 'Value']);
-  getBathroomBreakLimit(ss);
+  await getSheetByName(ss, CONFIG.SETTINGS_SHEET, ['Key', 'Value']);
+  await getBathroomBreakLimit(ss);
 }
 
-function processBarcode(studentId) {
+async function processBarcode(studentId) {
   try {
-    const lock = _acquireLock_(30000);
+    const lock = await _acquireLock_(30000);
     try {
-      ensureBathroomTrackerSetup_();
-      return recordBathroomBreak(studentId);
+      await ensureBathroomTrackerSetup_();
+      return await recordBathroomBreak(studentId);
     } finally {
       try { lock.releaseLock(); } catch (_) {}
     }
@@ -790,9 +817,9 @@ function processBarcode(studentId) {
   }
 }
 
-function recordBathroomBreak(studentId) {
-  const ss = _getSpreadsheet_();
-  const bathroomLogSheet = getSheetByName(ss, CONFIG.BATHROOM_LOG_SHEET, ['Timestamp', 'Student ID', 'Student Name', 'Period', 'Direction', 'Duration (minutes)']);
+async function recordBathroomBreak(studentId) {
+  const ss = await _getSpreadsheet_();
+  const bathroomLogSheet = await getSheetByName(ss, CONFIG.BATHROOM_LOG_SHEET, ['Timestamp', 'Student ID', 'Student Name', 'Period', 'Direction', 'Duration (minutes)']);
   const rosterSheet = ss.getSheetByName(CONFIG.ROSTER_SHEET);
 
   // Find student name
@@ -852,31 +879,31 @@ function recordBathroomBreak(studentId) {
     const now = new Date();
     const duration = Math.round((now - lastOutTime) / 60000);
     bathroomLogSheet.appendRow([now, studentId, studentName, studentPeriod, 'in', duration]);
-    _bumpVersion_(ss.getId());
+    await _bumpVersion_(ss.getId());
     return `${studentName} checked back in. Duration: ${duration} minutes.`;
   } else {
-    const limit = getBathroomBreakLimit(ss);
+    const limit = await getBathroomBreakLimit(ss);
     if (tripsToday >= limit) {
       throw new Error(`${studentName} has reached the bathroom break limit of ${limit}.`);
     }
     bathroomLogSheet.appendRow([new Date(), studentId, studentName, studentPeriod, 'out', '']);
-    _bumpVersion_(ss.getId());
+    await _bumpVersion_(ss.getId());
     return `${studentName} checked out for a bathroom break.`;
   }
 }
 
-function getBathroomAnalytics() {
-  const ss = _getSpreadsheet_();
+async function getBathroomAnalytics() {
+  const ss = await _getSpreadsheet_();
   const ssId = ss.getId();
-  const ver = _getVersion_(ssId);
+  const ver = await _getVersion_(ssId);
   const cacheKey = APP.CACHE_PREFIX_BATH_ANALYTICS + ssId + ':v' + ver;
-  const cached = _cacheGet_(cacheKey);
+  const cached = await _cacheGet_(cacheKey);
   if (cached) return cached;
 
   const bathroomLogSheet = ss.getSheetByName(CONFIG.BATHROOM_LOG_SHEET);
   if (!bathroomLogSheet) {
     const empty = { students: {}, periods: {} };
-    _cachePut_(cacheKey, empty, CONFIG.CACHE_TTL_BATHROOM);
+    await _cachePut_(cacheKey, empty, CONFIG.CACHE_TTL_BATHROOM);
     return empty;
   }
 
@@ -907,23 +934,23 @@ function getBathroomAnalytics() {
     }
   }
 
-  _cachePut_(cacheKey, analytics, CONFIG.CACHE_TTL_BATHROOM);
+  await _cachePut_(cacheKey, analytics, CONFIG.CACHE_TTL_BATHROOM);
   return analytics;
 }
 
-function getBathroomStatus(period) {
-  const ss = _getSpreadsheet_();
+async function getBathroomStatus(period) {
+  const ss = await _getSpreadsheet_();
   const p = String(period || '');
   const ssId = ss.getId();
-  const ver = _getVersion_(ssId);
+  const ver = await _getVersion_(ssId);
   const cacheKey = APP.CACHE_PREFIX_BATH_STATUS + ssId + ':' + p + ':v' + ver;
-  const cached = _cacheGet_(cacheKey);
+  const cached = await _cacheGet_(cacheKey);
   if (cached) return cached;
 
   const logSheet = ss.getSheetByName(CONFIG.BATHROOM_LOG_SHEET);
   if (!logSheet) {
     const empty = { out: [], in: [] };
-    _cachePut_(cacheKey, empty, CONFIG.CACHE_TTL_BATHROOM);
+    await _cachePut_(cacheKey, empty, CONFIG.CACHE_TTL_BATHROOM);
     return empty;
   }
 
@@ -962,6 +989,6 @@ function getBathroomStatus(period) {
   inside.sort((a, b) => a.name.localeCompare(b.name));
 
   const result = { out: out, in: inside };
-  _cachePut_(cacheKey, result, CONFIG.CACHE_TTL_BATHROOM);
+  await _cachePut_(cacheKey, result, CONFIG.CACHE_TTL_BATHROOM);
   return result;
 }

--- a/Code.gs
+++ b/Code.gs
@@ -893,52 +893,59 @@ async function recordBathroomBreak(studentId) {
 }
 
 async function getBathroomAnalytics() {
-  const ss = await _getSpreadsheetOrNull_();
-  if (!ss) {
-    return { students: {}, periods: {} };
-  }
-  const ssId = ss.getId();
-  const ver = await _getVersion_(ssId);
-  const cacheKey = APP.CACHE_PREFIX_BATH_ANALYTICS + ssId + ':v' + ver;
-  const cached = await _cacheGet_(cacheKey);
-  if (cached) return cached;
-
-  const bathroomLogSheet = ss.getSheetByName(CONFIG.BATHROOM_LOG_SHEET);
-  if (!bathroomLogSheet) {
-    const empty = { students: {}, periods: {} };
-    await _cachePut_(cacheKey, empty, CONFIG.CACHE_TTL_BATHROOM);
-    return empty;
-  }
-
-  const logData = bathroomLogSheet.getDataRange().getValues();
-  const analytics = { students: {}, periods: {} };
-  const today = new Date().setHours(0, 0, 0, 0);
-
-  for (let i = 1; i < logData.length; i++) {
-    const row = logData[i];
-    const logDate = new Date(row[0]).setHours(0, 0, 0, 0);
-    if (logDate !== today) continue;
-    const studentName = row[2];
-    const period = row[3];
-    const direction = row[4];
-    const duration = parseInt(row[5], 10) || 0;
-
-    if (direction === 'in') {
-      if (!analytics.students[studentName]) {
-        analytics.students[studentName] = { visits: 0, minutes: 0 };
-      }
-      if (!analytics.periods[period]) {
-        analytics.periods[period] = { visits: 0, minutes: 0 };
-      }
-      analytics.students[studentName].visits += 1;
-      analytics.students[studentName].minutes += duration;
-      analytics.periods[period].visits += 1;
-      analytics.periods[period].minutes += duration;
+  try {
+    const ss = await _getSpreadsheetOrNull_();
+    if (!ss) {
+      return { students: {}, periods: {} };
     }
-  }
+    const ssId = ss.getId();
+    const ver = await _getVersion_(ssId);
+    const cacheKey = APP.CACHE_PREFIX_BATH_ANALYTICS + ssId + ':v' + ver;
+    const cached = await _cacheGet_(cacheKey);
+    if (cached) return cached;
 
-  await _cachePut_(cacheKey, analytics, CONFIG.CACHE_TTL_BATHROOM);
-  return analytics;
+    const bathroomLogSheet = ss.getSheetByName(CONFIG.BATHROOM_LOG_SHEET);
+    if (!bathroomLogSheet) {
+      const empty = { students: {}, periods: {} };
+      await _cachePut_(cacheKey, empty, CONFIG.CACHE_TTL_BATHROOM);
+      return empty;
+    }
+
+    const logData = bathroomLogSheet.getDataRange().getValues();
+    const analytics = { students: {}, periods: {} };
+    const today = new Date().setHours(0, 0, 0, 0);
+
+    for (let i = 1; i < logData.length; i++) {
+      const row = logData[i];
+      const logDate = new Date(row[0]).setHours(0, 0, 0, 0);
+      if (logDate !== today) continue;
+      const studentName = row[2];
+      const period = row[3];
+      const direction = row[4];
+      const duration = parseInt(row[5], 10) || 0;
+
+      if (direction === 'in') {
+        if (!analytics.students[studentName]) {
+          analytics.students[studentName] = { visits: 0, minutes: 0 };
+        }
+        if (!analytics.periods[period]) {
+          analytics.periods[period] = { visits: 0, minutes: 0 };
+        }
+        analytics.students[studentName].visits += 1;
+        analytics.students[studentName].minutes += duration;
+        analytics.periods[period].visits += 1;
+        analytics.periods[period].minutes += duration;
+      }
+    }
+
+    await _cachePut_(cacheKey, analytics, CONFIG.CACHE_TTL_BATHROOM);
+    return analytics;
+  } catch (err) {
+    if (err && typeof err.message === 'string' && err.message.includes('No data spreadsheet')) {
+      return { students: {}, periods: {} };
+    }
+    throw err;
+  }
 }
 
 async function getBathroomStatus(period) {

--- a/Code.gs
+++ b/Code.gs
@@ -942,7 +942,10 @@ async function getBathroomAnalytics() {
 }
 
 async function getBathroomStatus(period) {
-  const ss = await _getSpreadsheet_();
+  const ss = await _getSpreadsheetOrNull_();
+  if (!ss) {
+    return { out: [], in: [] };
+  }
   const p = String(period || '');
   const ssId = ss.getId();
   const ver = await _getVersion_(ssId);

--- a/Code.gs
+++ b/Code.gs
@@ -893,7 +893,10 @@ async function recordBathroomBreak(studentId) {
 }
 
 async function getBathroomAnalytics() {
-  const ss = await _getSpreadsheet_();
+  const ss = await _getSpreadsheetOrNull_();
+  if (!ss) {
+    return { students: {}, periods: {} };
+  }
   const ssId = ss.getId();
   const ver = await _getVersion_(ssId);
   const cacheKey = APP.CACHE_PREFIX_BATH_ANALYTICS + ssId + ':v' + ver;

--- a/Code.gs
+++ b/Code.gs
@@ -381,7 +381,7 @@ async function openLoggerPopup() {
     .setHeight(CONFIG.POPUP_HEIGHT);
   try { SpreadsheetApp.getUi().showModalDialog(html, 'Issue Logger'); } catch (e) {}
 }
-async function doGet() {
+function doGet() {
   return HtmlService.createTemplateFromFile('sidebar')
     .evaluate()
     .setTitle('Issue Logger')

--- a/analytics.html
+++ b/analytics.html
@@ -167,7 +167,7 @@
 
   const setActiveChip = (selector, isActive)=> $$(selector).forEach(el=> el.classList.toggle('active', isActive(el)));
 
-  function initAnalyticsToolbar(){
+  async function initAnalyticsToolbar(){
     setActiveChip('.analytics-toolbar .chip-sm[data-topn]', el=>{
       const v = el.getAttribute('data-topn');
       return (v==='all' && analyticsConfig.topStudentsN==='all') || (+v===analyticsConfig.topStudentsN);
@@ -175,18 +175,18 @@
     setActiveChip('.analytics-toolbar .chip-sm[data-density]', el=> el.getAttribute('data-density')===analyticsConfig.density);
 
     $$('.analytics-toolbar .chip-sm[data-topn]').forEach(btn=>{
-      btn.addEventListener('click', ()=>{
+      btn.addEventListener('click', async ()=>{
         const v = btn.getAttribute('data-topn');
         analyticsConfig.topStudentsN = (v==='all') ? 'all' : parseInt(v,10);
         setActiveChip('.analytics-toolbar .chip-sm[data-topn]', el=> el===btn);
-        if (currentView==='analytics') renderAnalytics();
+        if (currentView==='analytics') await renderAnalytics();
       });
     });
     $$('.analytics-toolbar .chip-sm[data-density]').forEach(btn=>{
-      btn.addEventListener('click', ()=>{
+      btn.addEventListener('click', async ()=>{
         analyticsConfig.density = btn.getAttribute('data-density');
         setActiveChip('.analytics-toolbar .chip-sm[data-density]', el=> el===btn);
-        if (currentView==='analytics') renderAnalytics();
+        if (currentView==='analytics') await renderAnalytics();
       });
     });
 
@@ -199,12 +199,12 @@
           analyticsConfig.tableSort.key = key;
           analyticsConfig.tableSort.dir = (key==='student'?'asc':'desc');
         }
-        renderAnalytics();
+        await renderAnalytics();
       });
     });
   }
 
-  function renderAnalytics(){
+  async function renderAnalytics(){
     const totalsByIssue = (COUNTS.issues || []).map((lab, i)=>{
       let sum = 0; (COUNTS.rows||[]).forEach(r => sum += (r.counts[i]||0)); return { lab, sum };
     });
@@ -224,7 +224,7 @@
     $('#kpiTopStudentCount').textContent = topStudent.sum ? `${topStudent.sum} total` : '';
     $('#kpiIssueVariety').textContent = String(issueVariety);
 
-    drawBarChart($('#chartIssues'),
+    await drawBarChart($('#chartIssues'),
       totalsByIssue.map(x=>x.lab),
       totalsByIssue.map(x=>x.sum),
       { title:'Issues', maxBars: 14, density: analyticsConfig.density }
@@ -234,7 +234,7 @@
     if (analyticsConfig.topStudentsN !== 'all'){
       studentsSorted = studentsSorted.slice(0, analyticsConfig.topStudentsN);
     }
-    drawBarChart($('#chartStudents'),
+    await drawBarChart($('#chartStudents'),
       studentsSorted.map(x=>x.student),
       studentsSorted.map(x=>x.sum),
       { title:'Students', maxBars: (analyticsConfig.topStudentsN==='all'? 18 : analyticsConfig.topStudentsN), density: analyticsConfig.density }
@@ -269,7 +269,7 @@
     setActiveChip('.analytics-toolbar .chip-sm[data-density]', el=> el.getAttribute('data-density')===analyticsConfig.density);
   }
 
-  function renderBathroomAnalytics() {
+  async function renderBathroomAnalytics() {
     google.script.run.withSuccessHandler(data => {
       const studentBody = $('#bathroomAnalyticsTable tbody');
       const periodBody = $('#bathroomPeriodTable tbody');
@@ -322,7 +322,7 @@
   renderBathroomAnalytics();
 
   // Improved bar chart: ensures labels and values don't overlap content
-  function drawBarChart(canvas, labels, values, opts = {}) {
+  async function drawBarChart(canvas, labels, values, opts = {}) {
     const DPR = Math.max(1, window.devicePixelRatio || 1);
 
     const density = opts.density || 'comfortable';

--- a/analytics.html
+++ b/analytics.html
@@ -270,52 +270,71 @@
   }
 
   async function renderBathroomAnalytics() {
-    google.script.run.withSuccessHandler(data => {
+    google.script.run.withSuccessHandler(state => {
       const studentBody = $('#bathroomAnalyticsTable tbody');
       const periodBody = $('#bathroomPeriodTable tbody');
       studentBody.innerHTML = '';
       periodBody.innerHTML = '';
-      const students = data.students || {};
-      const periods = data.periods || {};
-      if (Object.keys(students).length === 0) {
-        const tr = document.createElement('tr');
-        const td = document.createElement('td');
-        td.colSpan = 3;
-        td.textContent = 'No bathroom logs recorded today.';
-        tr.appendChild(td);
-        studentBody.appendChild(tr);
-      } else {
-        for (const student in students) {
+
+      if (!state || !state.attached) {
+        const tr1 = document.createElement('tr');
+        const td1 = document.createElement('td');
+        td1.colSpan = 3;
+        td1.textContent = 'No data spreadsheet is attached.';
+        tr1.appendChild(td1);
+        const tr2 = document.createElement('tr');
+        const td2 = document.createElement('td');
+        td2.colSpan = 3;
+        td2.textContent = 'No data spreadsheet is attached.';
+        tr2.appendChild(td2);
+        studentBody.appendChild(tr1);
+        periodBody.appendChild(tr2);
+        return;
+      }
+
+      google.script.run.withSuccessHandler(data => {
+        const students = data.students || {};
+        const periods = data.periods || {};
+        if (Object.keys(students).length === 0) {
           const tr = document.createElement('tr');
-          const s = students[student] || {};
+          const td = document.createElement('td');
+          td.colSpan = 3;
+          td.textContent = 'No bathroom logs recorded today.';
+          tr.appendChild(td);
+          studentBody.appendChild(tr);
+        } else {
+          for (const student in students) {
+            const tr = document.createElement('tr');
+            const s = students[student] || {};
             tr.append(
               el('td', {}, student),
               el('td', {}, String(s.visits || 0)),
               el('td', {}, String(s.minutes || 0))
             );
-          studentBody.appendChild(tr);
+            studentBody.appendChild(tr);
+          }
         }
-      }
-      if (Object.keys(periods).length === 0) {
-        const tr = document.createElement('tr');
-        const td = document.createElement('td');
-        td.colSpan = 3;
-        td.textContent = 'No bathroom logs recorded today.';
-        tr.appendChild(td);
-        periodBody.appendChild(tr);
-      } else {
-        for (const period in periods) {
+        if (Object.keys(periods).length === 0) {
           const tr = document.createElement('tr');
-          const p = periods[period] || {};
+          const td = document.createElement('td');
+          td.colSpan = 3;
+          td.textContent = 'No bathroom logs recorded today.';
+          tr.appendChild(td);
+          periodBody.appendChild(tr);
+        } else {
+          for (const period in periods) {
+            const tr = document.createElement('tr');
+            const p = periods[period] || {};
             tr.append(
               el('td', {}, period),
               el('td', {}, String(p.visits || 0)),
               el('td', {}, String(p.minutes || 0))
             );
-          periodBody.appendChild(tr);
+            periodBody.appendChild(tr);
+          }
         }
-      }
-    }).getBathroomAnalytics();
+      }).getBathroomAnalytics();
+    }).getAppState();
   }
 
   // Call the function to render the analytics

--- a/sidebar.html
+++ b/sidebar.html
@@ -393,6 +393,7 @@
       </div>
       <div class="setup-actions">
         <button id="setupCancel" class="btn ghost">Skip for now</button>
+        <button id="setupFind" class="btn ghost">Find Existing</button>
         <button id="setupBuild" class="btn">Build Sheets</button>
       </div>
     </div>
@@ -419,8 +420,8 @@
   const $$ = q => Array.from(document.querySelectorAll(q));
   const debounce = (fn, ms=180) => { let t; return (...args)=>{ clearTimeout(t); t=setTimeout(()=>fn(...args),ms); }; };
 
-  function toast(msg){ const t=$('#toast'); t.textContent = msg || 'Saved'; t.classList.add('show'); setTimeout(()=>t.classList.remove('show'), 1400); }
-  function el(tag, attrs={}, ...kids){
+  async function toast(msg){ const t=$('#toast'); t.textContent = msg || 'Saved'; t.classList.add('show'); setTimeout(()=>t.classList.remove('show'), 1400); }
+  async function el(tag, attrs={}, ...kids){
     const e = document.createElement(tag);
     for (const [k,v] of Object.entries(attrs||{})){
       if (k==='class') e.className=v;
@@ -434,10 +435,10 @@
   }
 
   // ==================== First-run bootstrap ====================
-  function bootstrap(){
+  async function bootstrap(){
     $('#mainLog').setAttribute('aria-busy','true');
     $('#mainAnalytics').setAttribute('aria-busy','true');
-    google.script.run.withSuccessHandler((state)=>{
+    google.script.run.withSuccessHandler(async (state)=>{
       APP = { attached: !!state?.attached, ssId: state?.ssId || null, ssUrl: state?.ssUrl || null };
 
       $('#openSheet').style.display = APP.ssUrl ? 'inline-flex' : 'none';
@@ -448,45 +449,45 @@
         showSetup(true);
       } else {
         showSetup(false);
-        load();
+        await load();
       }
       $('#mainLog').setAttribute('aria-busy','false');
       $('#mainAnalytics').setAttribute('aria-busy','false');
 
-      initAnalyticsToolbar();
-      initLayoutToggle();
+      await initAnalyticsToolbar();
+      await initLayoutToggle();
     }).getAppState();
   }
-  function showSetup(show){ $('#setup').classList.toggle('active', !!show); }
+  async function showSetup(show){ $('#setup').classList.toggle('active', !!show); }
 
   // ==================== Layout Toggle ====================
-  function initLayoutToggle(){
+  async function initLayoutToggle(){
     const listBtn = $('#btnListMode');
     const gridBtn = $('#btnGridMode');
 
-    function update(){
+    async function update(){
       listBtn.classList.toggle('active', studentLayout === 'list');
       gridBtn.classList.toggle('active', studentLayout === 'grid');
       $('#studentList').classList.toggle('grid', studentLayout === 'grid');
-      renderStudents();
+      await renderStudents();
     }
 
-    listBtn.addEventListener('click', ()=>{ studentLayout = 'list'; update(); });
-    gridBtn.addEventListener('click', ()=>{ studentLayout = 'grid'; update(); });
-    update();
+    listBtn.addEventListener('click', async ()=>{ studentLayout = 'list'; await update(); });
+    gridBtn.addEventListener('click', async ()=>{ studentLayout = 'grid'; await update(); });
+    await update();
   }
 
   // ==================== View Switch ====================
-  function setView(view){
+  async function setView(view){
     currentView = view;
     $('#viewLog').classList.toggle('active', view==='log');
     $('#viewAnalytics').classList.toggle('active', view==='analytics');
     $('#mainLog').classList.toggle('active', view==='log');
     $('#mainAnalytics').classList.toggle('active', view==='analytics');
     if (view === 'analytics') {
-      renderAnalytics(); // use local COUNTS
+      await renderAnalytics(); // use local COUNTS
       if (typeof renderBathroomAnalytics === 'function') {
-        renderBathroomAnalytics();
+        await renderBathroomAnalytics();
       }
     }
     if (view === 'log' && barcodeInput) {
@@ -495,7 +496,7 @@
   }
 
   // ==================== Period Tabs & Switching ====================
-  function setPeriod(p){
+  async function setPeriod(p){
     currentPeriod = p;
     currentStudent = null;
 
@@ -506,22 +507,21 @@
     if (searchInput) searchInput.value = '';
 
     // Optimistic UI render
-    renderTabs();
+    await renderTabs();
 
     // Fetch counts for the selected period
-    google.script.run.withSuccessHandler((snap)=>{
+    google.script.run.withSuccessHandler(async (snap)=>{
       COUNTS = snap || { issues:[], rows:[] };
-
-      renderFilters();
-      renderStudents();
-      renderDetail();
-      if (currentView === 'analytics') renderAnalytics();
-      refreshStatus();
-      if (typeof renderBathroomAnalytics === 'function') renderBathroomAnalytics();
+      await renderFilters();
+      await renderStudents();
+      await renderDetail();
+      if (currentView === 'analytics') await renderAnalytics();
+      await refreshStatus();
+      if (typeof renderBathroomAnalytics === 'function') await renderBathroomAnalytics();
     }).getCountsSnapshot(currentPeriod);
   }
 
-  function renderTabs(){
+  async function renderTabs(){
     const wrap = $('#tabs'); wrap.innerHTML = '';
     DATA.periods.forEach(p=>{
       wrap.appendChild(el('button', {
@@ -532,7 +532,7 @@
   }
 
   // ==================== Filters (issues) ====================
-  function renderFilters(){
+  async function renderFilters(){
     const host = $('#issueFilters'); host.innerHTML = '';
     if (!COUNTS.issues.length) return;
 
@@ -542,8 +542,8 @@
         onclick: ()=>{
           if (activeIssueFilters.has(idx)) activeIssueFilters.delete(idx);
           else activeIssueFilters.add(idx);
-          renderFilters();
-          renderStudents();
+          await renderFilters();
+          await renderStudents();
         }
       }, label);
       host.appendChild(chip);
@@ -555,8 +555,8 @@
           class:'filter-chip',
           onclick: ()=>{
             activeIssueFilters.clear();
-            renderFilters();
-            renderStudents();
+            await renderFilters();
+            await renderStudents();
           }
         }, 'Clear filters')
       );
@@ -564,7 +564,7 @@
   }
 
   // ==================== Students ====================
-  function renderStudents(){
+  async function renderStudents(){
     const list = $('#studentList'); list.innerHTML = '';
     const namesAll = (DATA.perMap[currentPeriod] || []);
     const names = namesAll
@@ -581,7 +581,7 @@
 
     names.forEach((name)=>{
       if (studentLayout === 'grid'){
-        const card = el('div', { class:'student-item' + (name===currentStudent?' active':''), onclick: ()=> selectStudent(name) },
+        const card = el('div', { class:'student-item' + (name===currentStudent?' active':''), onclick: async ()=> await selectStudent(name) },
           el('div', { class:'avatar' }, name.trim().charAt(0).toUpperCase() || 'S'),
           el('div', { class:'student-col' },
             el('div', { class:'student-meta' },
@@ -594,7 +594,7 @@
         card.dataset.name = name;
         list.appendChild(card);
       } else {
-        const row = el('div', { class:'student-item' + (name===currentStudent?' active':''), onclick: ()=> selectStudent(name) },
+        const row = el('div', { class:'student-item' + (name===currentStudent?' active':''), onclick: async ()=> await selectStudent(name) },
           el('div', { class:'avatar' }, name.trim().charAt(0).toUpperCase() || 'S'),
           el('div', { class:'student-col' },
             el('div', { class:'student-meta' },
@@ -609,15 +609,15 @@
       }
     });
 
-    fillListBadges();
-    if (!currentStudent && names.length) selectStudent(names[0]);
+    await fillListBadges();
+    if (!currentStudent && names.length) await selectStudent(names[0]);
   }
 
   /**
    * Populate per-student top issue badges.
    * Shows up to 5 most frequent issues per student.
    */
-  function fillListBadges(){
+  async function fillListBadges(){
     if (!COUNTS.issues.length) return;
     const map = new Map(COUNTS.rows.map(r => [r.student, r.counts]));
 
@@ -646,14 +646,14 @@
     });
   }
 
-  function selectStudent(name){
+  async function selectStudent(name){
     currentStudent = name;
     $$('.student-item').forEach(r=> r.classList.toggle('active', r.dataset.name===name));
-    renderDetail();
+    await renderDetail();
   }
 
   // ==================== Detail panel ====================
-  function renderDetail(){
+  async function renderDetail(){
     const nameBox = $('#detailName');
     const subBox = $('#detailSub');
     const grid = $('#issueGrid');
@@ -684,13 +684,13 @@
         el('span', {
           class:'label',
           title:'Click to +1',
-          onclick: ()=> increment(issue, i, selectedStudent, selectedPeriod)
+          onclick: async ()=> await increment(issue, i, selectedStudent, selectedPeriod)
         }, issue),
         el('div', { class:'actions' },
           el('button', {
             class:'icon-btn minus',
             title:'-1 (undo)',
-            onclick: (ev)=>{ ev.stopPropagation(); decrement(issue, i, selectedStudent, selectedPeriod); }
+            onclick: async (ev)=>{ ev.stopPropagation(); await decrement(issue, i, selectedStudent, selectedPeriod); }
           }, '−'),
           el('span', { class:'count-badge', id:`cnt_${i}` }, String(val))
         )
@@ -700,7 +700,7 @@
   }
 
   // ==================== Fast local updates ====================
-  function applyDeltaToCounts(studentName, issueLabel, delta) {
+  async function applyDeltaToCounts(studentName, issueLabel, delta) {
     if (!studentName || !issueLabel) return;
 
     const namesInPeriod = (DATA.perMap[currentPeriod] || []);
@@ -723,7 +723,7 @@
     row.counts[issueIdx] = Math.max(0, val);
   }
 
-  function updateDetailAndBadges(studentName, issueIndexForBadge) {
+  async function updateDetailAndBadges(studentName, issueIndexForBadge) {
     if (currentStudent === studentName) {
       const idxByIssue = new Map(COUNTS.issues.map((lab,i)=>[lab,i]));
       const issueLabel = DATA.issues[issueIndexForBadge];
@@ -735,32 +735,32 @@
         if (badge) badge.textContent = String(v);
       }
     }
-    fillListBadges();
-    if (currentView === 'analytics') renderAnalytics();
+    await fillListBadges();
+    if (currentView === 'analytics') await renderAnalytics();
   }
 
   // ==================== Increment / Decrement ====================
-  function increment(issue, issueIndex, studentName, periodName){
+  async function increment(issue, issueIndex, studentName, periodName){
     if (!studentName) return;
     const notes = ($('#note').value || '').trim();
     lastIssueIndex = issueIndex;
 
-    applyDeltaToCounts(studentName, issue, +1);
-    updateDetailAndBadges(studentName, issueIndex);
+    await applyDeltaToCounts(studentName, issue, +1);
+    await updateDetailAndBadges(studentName, issueIndex);
     $('#note').value = '';
 
-    google.script.run.withSuccessHandler((res)=>{
+    google.script.run.withSuccessHandler(async (res)=>{
       if (res && res.ok){
         toast(`+1 ${issue} for ${studentName}`);
       } else {
-        applyDeltaToCounts(studentName, issue, -1);
-        updateDetailAndBadges(studentName, issueIndex);
+        await applyDeltaToCounts(studentName, issue, -1);
+        await updateDetailAndBadges(studentName, issueIndex);
         toast((res && res.message) ? res.message : 'Failed to save');
       }
     }).logEntries({ entries: [{ student: studentName, issue, notes }] });
   }
 
-  function decrement(issue, issueIndex, studentName, periodName){
+  async function decrement(issue, issueIndex, studentName, periodName){
     if (!studentName) return;
 
     const idxByIssue = new Map(COUNTS.issues.map((lab,i)=>[lab,i]));
@@ -771,15 +771,15 @@
       return;
     }
 
-    applyDeltaToCounts(studentName, issue, -1);
-    updateDetailAndBadges(studentName, issueIndex);
+    await applyDeltaToCounts(studentName, issue, -1);
+    await updateDetailAndBadges(studentName, issueIndex);
 
-    google.script.run.withSuccessHandler((res)=>{
+    google.script.run.withSuccessHandler(async (res)=>{
       if (res && res.ok){
         toast(`−1 ${issue} for ${studentName}`);
       } else {
-        applyDeltaToCounts(studentName, issue, +1);
-        updateDetailAndBadges(studentName, issueIndex);
+        await applyDeltaToCounts(studentName, issue, +1);
+        await updateDetailAndBadges(studentName, issueIndex);
         const msg = (res && res.message) ? res.message : 'Nothing to undo';
         toast(msg);
       }
@@ -787,9 +787,9 @@
   }
 
   // ==================== Data loaders ====================
-  function load(){
+  async function load(){
     $('#refresh').disabled = true;
-    google.script.run.withSuccessHandler((data)=>{
+    google.script.run.withSuccessHandler(async (data)=>{
       DATA = data || { periods:[], perMap:{}, issues:[] };
       if (!DATA.periods.length){
         $('#tabs').innerHTML = '';
@@ -798,14 +798,16 @@
         return;
       }
       if (!currentPeriod) currentPeriod = DATA.periods[0];
-      renderTabs();
+      await renderTabs();
 
-      google.script.run.withSuccessHandler((snap)=>{
+      google.script.run.withSuccessHandler(async (snap)=>{
         COUNTS = snap || { issues:[], rows:[] };
-        renderFilters(); renderStudents(); renderDetail();
-        if (currentView==='analytics') renderAnalytics();
-        refreshStatus();
-        if (typeof renderBathroomAnalytics === 'function') renderBathroomAnalytics();
+        await renderFilters();
+        await renderStudents();
+        await renderDetail();
+        if (currentView==='analytics') await renderAnalytics();
+        await refreshStatus();
+        if (typeof renderBathroomAnalytics === 'function') await renderBathroomAnalytics();
         $('#refresh').disabled = false;
       }).getCountsSnapshot(currentPeriod);
     }).getData();
@@ -825,11 +827,11 @@
     }, 100);
   });
 
-  function handleScan(code){
+  async function handleScan(code){
     $('#scanResult').innerText = `Processing scan: ${code}`;
-    refreshStatus();
+    await refreshStatus();
     if(typeof renderBathroomAnalytics === 'function'){
-      renderBathroomAnalytics();
+      await renderBathroomAnalytics();
     }
     google.script.run
       .withSuccessHandler(updateUI)
@@ -837,26 +839,26 @@
       .processBarcode(code);
   }
 
-  function updateUI(message){
+  async function updateUI(message){
     $('#scanResult').innerText = message;
-    refreshStatus();
+    await refreshStatus();
     if(typeof renderBathroomAnalytics === 'function'){
-      renderBathroomAnalytics();
+      await renderBathroomAnalytics();
     }
     barcodeInput.focus();
   }
 
-  function showError(error){
+  async function showError(error){
     $('#scanResult').innerText = error.message;
     barcodeInput.focus();
   }
 
-  function refreshStatus(){
+  async function refreshStatus(){
     const period = currentPeriod || null;
-    google.script.run.withSuccessHandler(renderStatus).getBathroomStatus(period);
+    google.script.run.withSuccessHandler(async status => { await renderStatus(status); }).getBathroomStatus(period);
   }
 
-  function renderStatus(status){
+  async function renderStatus(status){
     const outList = $('#outList');
     const inList = $('#inList');
     outList.innerHTML = '';
@@ -892,11 +894,11 @@
     $('#adminMenu').classList.remove('open');
     if (!APP.attached) return toast('Sheets not set up yet.');
     if (!confirm('Delete ALL logs (QuickLog, bathroom, analytics)? This cannot be undone.')) return;
-    google.script.run.withSuccessHandler((res)=>{
+    google.script.run.withSuccessHandler(async (res)=>{
       toast(res && res.message || 'Cleared.');
       COUNTS = { issues: COUNTS.issues, rows: [] };
-      renderStudents(); renderDetail();
-      if (currentView==='analytics') renderAnalytics();
+      await renderStudents(); await renderDetail();
+      if (currentView==='analytics') await renderAnalytics();
     }).clearAllLogs();
   });
   $('#menuOpen').addEventListener('click', ()=>{
@@ -904,27 +906,42 @@
     if (APP.ssUrl) window.open(APP.ssUrl, '_blank'); else toast('No spreadsheet yet.');
   });
 
-  $('#setupBuild').addEventListener('click', ()=>{
+  $('#setupBuild').addEventListener('click', async ()=>{
     const name = ($('#ssName').value || '').trim() || 'Issue Logger (Data)';
     const seed = $('#seedDemo').checked;
     $('#setupSpinner').classList.add('show');
-    $('#setupBuild').disabled = true; $('#setupCancel').disabled = true;
-    google.script.run.withSuccessHandler((res)=>{
+    $('#setupBuild').disabled = true; $('#setupCancel').disabled = true; $('#setupFind').disabled = true;
+    google.script.run.withSuccessHandler(async (res)=>{
       $('#setupSpinner').classList.remove('show');
-      $('#setupBuild').disabled = false; $('#setupCancel').disabled = false;
+      $('#setupBuild').disabled = false; $('#setupCancel').disabled = false; $('#setupFind').disabled = false;
       if (res && res.ok){
         APP.attached = true; APP.ssId = res.ssId; APP.ssUrl = res.ssUrl;
         $('#openSheet').style.display = APP.ssUrl ? 'inline-flex' : 'none';
         $('#refresh').disabled = false; $('#menuBuild').style.display = 'none';
-        toast('Sheets built.'); showSetup(false); load();
+        toast('Sheets built.'); showSetup(false); await load();
       } else { toast(res && res.message ? res.message : 'Build failed.'); }
     }).buildSheets({ seed, name });
+  });
+  $('#setupFind').addEventListener('click', async ()=>{
+    const name = ($('#ssName').value || '').trim() || 'Issue Logger (Data)';
+    $('#setupSpinner').classList.add('show');
+    $('#setupBuild').disabled = true; $('#setupCancel').disabled = true; $('#setupFind').disabled = true;
+    google.script.run.withSuccessHandler(async (res)=>{
+      $('#setupSpinner').classList.remove('show');
+      $('#setupBuild').disabled = false; $('#setupCancel').disabled = false; $('#setupFind').disabled = false;
+      if (res && res.ok){
+        APP.attached = true; APP.ssId = res.ssId; APP.ssUrl = res.ssUrl;
+        $('#openSheet').style.display = APP.ssUrl ? 'inline-flex' : 'none';
+        $('#refresh').disabled = false; $('#menuBuild').style.display = 'none';
+        toast('Spreadsheet attached.'); showSetup(false); await load();
+      } else { toast(res && res.message ? res.message : 'Sheet not found.'); }
+    }).findSpreadsheet(name);
   });
   $('#setupCancel').addEventListener('click', ()=> showSetup(false));
 
   $('#openSheet').addEventListener('click', ()=> APP.ssUrl ? window.open(APP.ssUrl, '_blank') : toast('No spreadsheet yet.'));
-  $('#search').addEventListener('input', debounce((e)=>{ searchTerm = (e.target.value || '').trim().toLowerCase(); renderStudents(); }, 120));
-  $('#refresh').addEventListener('click', ()=> { if (!APP.attached) return; load(); if (currentView==='analytics') setTimeout(renderAnalytics, 50); });
+  $('#search').addEventListener('input', debounce(async (e)=>{ searchTerm = (e.target.value || '').trim().toLowerCase(); await renderStudents(); }, 120));
+  $('#refresh').addEventListener('click', async ()=> { if (!APP.attached) return; await load(); if (currentView==='analytics') setTimeout(()=>renderAnalytics(), 50); });
   $('#clearNote').addEventListener('click', ()=> $('#note').value='');
   $('#viewLog').addEventListener('click', ()=> setView('log'));
   $('#viewAnalytics').addEventListener('click', ()=> setView('analytics'));

--- a/sidebar.html
+++ b/sidebar.html
@@ -854,6 +854,7 @@
   }
 
   async function refreshStatus(){
+    if (!APP.attached) return;
     const period = currentPeriod || null;
     google.script.run.withSuccessHandler(async status => { await renderStatus(status); }).getBathroomStatus(period);
   }


### PR DESCRIPTION
## Summary
- Avoid errors in `getBathroomStatus` when no data spreadsheet is attached
- Skip status refresh in sidebar when spreadsheet isn't attached

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af6d0265b0832fb900abbb3c4755d4